### PR TITLE
fixed no image issue

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -51,6 +51,10 @@ class Item extends React.Component {
             <div className="col-6">
               <img
                 src={this.props.item.image}
+                onError={({ currentTarget }) => {
+                  currentTarget.onerror = null;
+                  currentTarget.src = "/placeholder.png";
+                }}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -39,6 +39,10 @@ const ItemPreview = (props) => {
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
+        onError={({ currentTarget }) => {
+          currentTarget.onerror = null;
+          currentTarget.src = "/placeholder.png";
+        }}
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">


### PR DESCRIPTION
# Description
<img width="1512" alt="Screenshot 2022-08-04 at 16 55 26" src="https://user-images.githubusercontent.com/80941955/182836176-1a05906a-35e9-49a2-ab40-18e2f7c13d04.png">

When a user creates an item with no image, a placeholder is used instead. 
